### PR TITLE
[css] use sans serif font for all elements on the site

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -3,6 +3,7 @@ html, body {
     background: linear-gradient(90deg, rgb(49, 48, 47) 0%, rgb(90, 90, 88) 25%, rgb(119, 115, 111) 50%,rgb(85, 80, 75) 75%, rgb(49, 47, 43) 100%);
     scroll-behavior: smooth;
     margin: 0px;
+    font-family: sans-serif;
 }
 .maincontent {
     user-select: none;


### PR DESCRIPTION
There should always be a default font defined on websites. This PR adds the sans-serif font on the body element, so child element applies that font two. You can also set an order of fonts (starting with the first). The browser then selects the first font it supports:

```css
font-family: arial, sans-serif;
```

With sans-serif:
![image](https://user-images.githubusercontent.com/38733246/134953743-0d38ba53-9196-45cc-9282-03fe91411136.png)


Without any font defined:
![image](https://user-images.githubusercontent.com/38733246/134953821-56d41f04-6752-4e9f-af1d-a423c1812710.png)
